### PR TITLE
adding button_css configuration field

### DIFF
--- a/supersaas.xml
+++ b/supersaas.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@supersaas.com</authorEmail>
 	<authorUrl>www.supersaas.com</authorUrl>
-	<version>2.2</version>
+	<version>2.3</version>
 	<description>PLG_CONTENT_SS_DESCRIPTION</description>
 	<files>
 		<filename plugin="supersaas">supersaas.php</filename>
@@ -60,6 +60,12 @@
 					type="text"
 					label="PLG_CONTENT_SS_SCHEDULE"
 					description="PLG_CONTENT_SS_SCHEDULE"
+				/>
+				<field
+					name="button_css"
+					type="text"
+					label="PLG_CONTENT_SS_CSS"
+					description="PLG_CONTENT_SS_CSS"
 				/>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
Makes plugin configurable for the Button CSS rendered on the frontend. Here, this optional setting allows the site creator to specify an existing CSS style, if they want to have the button rendered in the same style as other existing buttons (for visual consistency).